### PR TITLE
switching api url to api.track.toggl.com, as requested by toggl.com.

### DIFF
--- a/measureit.sh
+++ b/measureit.sh
@@ -37,19 +37,19 @@ function make_entry() {
 
   if [ -n "$project_id" ]; then
      json="{\"time_entry\":{\"description\":\"$1\",\"created_with\":\"measureit\",\"start\":\"$2\",\"duration\":$3,\"billable\":$billable,\"pid\":$project_id}}"
-  else 
+  else
      json="{\"time_entry\":{\"description\":\"$1\",\"created_with\":\"measureit\",\"start\":\"$2\",\"duration\":$3,\"billable\":$billable}}"
   fi
 
   curl -v -u $4:api_token \
     -H "Content-Type: application/json" \
     -d "$json" \
-    -X POST https://www.toggl.com/api/v8/time_entries 2>/dev/null >/dev/null
+    -X POST https://api.track.toggl.com/api/v8/time_entries 2>/dev/null >/dev/null
   echo "$eb $1 $2 $3 sec $ep"
 }
 
 function import_projects() {
-  curl -u "$1:api_token" -X GET "https://www.toggl.com/api/v8/me?with_related_data=true" 2>/dev/null|jq '.data.projects'|grep -e \"id -e \"name|while read l
+  curl -u "$1:api_token" -X GET "https://api.track.toggl.com/api/v8/me?with_related_data=true" 2>/dev/null|jq '.data.projects'|grep -e \"id -e \"name|while read l
  do
   v=`echo $l|cut -d":" -f2|cut -d, -f1|cut -d" " -f2`;
   id=$v;
@@ -61,8 +61,8 @@ function import_projects() {
    echo "$id;$name" >> $projects
   fi
 done
- 
- 
+
+
 }
 
 if [ -z "$2" ]; then
@@ -85,7 +85,7 @@ n=0
 wold=""
 told=$(date +"%Y-%m-%dT%H:%M:%S+01:00")
 
-api_token=$(curl -u $TUSER:$TPASS -X GET https://www.toggl.com/api/v8/me 2>/dev/null | jq -r ".data.api_token");
+api_token=$(curl -u $TUSER:$TPASS -X GET https://api.track.toggl.com/api/v8/me 2>/dev/null | jq -r ".data.api_token");
 import_projects $api_token;
 
 while sleep $STEP; do
@@ -110,7 +110,7 @@ while sleep $STEP; do
       fi
     done);
     if [ -z "$ig" ] && [ $n -gt $INTERVAL ]; then
-      api_token=$(curl -u $TUSER:$TPASS -X GET https://www.toggl.com/api/v8/me 2>/dev/null | jq -r ".data.api_token")
+      api_token=$(curl -u $TUSER:$TPASS -X GET https://api.track.toggl.com/api/v8/me 2>/dev/null | jq -r ".data.api_token")
       make_entry "$wold" "$told" "$n" "$api_token" "$project_id" "$notbill"
     fi
     n=0

--- a/measureit.sh
+++ b/measureit.sh
@@ -66,8 +66,9 @@ done
 }
 
 if [ -z "$2" ]; then
-  echo "Usage: <toggl user name> <toggl password> [minimal interval] [step]"
-  exit
+    echo -e "Usage:\n\t$(basename $0) <toggl user name> <toggl password> [minimal interval] [step]"
+    echo -e "\t$(basename $0) --token <api token> [minimal interval] [step]\n"
+    exit
 fi
 
 TUSER=$1
@@ -85,7 +86,15 @@ n=0
 wold=""
 told=$(date +"%Y-%m-%dT%H:%M:%S+01:00")
 
-api_token=$(curl -u $TUSER:$TPASS -X GET https://api.track.toggl.com/api/v8/me 2>/dev/null | jq -r ".data.api_token");
+get_api_token(){
+    if [ "$TUSER" == "--token" ] ; then
+        echo $TPASS
+    else
+        curl -u $TUSER:$TPASS -X GET https://api.track.toggl.com/api/v8/me 2>/dev/null | jq -r ".data.api_token"
+    fi
+}
+
+api_token=$(get_api_token)
 import_projects $api_token;
 
 while sleep $STEP; do
@@ -110,7 +119,7 @@ while sleep $STEP; do
       fi
     done);
     if [ -z "$ig" ] && [ $n -gt $INTERVAL ]; then
-      api_token=$(curl -u $TUSER:$TPASS -X GET https://api.track.toggl.com/api/v8/me 2>/dev/null | jq -r ".data.api_token")
+      api_token=$(get_api_token)
       make_entry "$wold" "$told" "$n" "$api_token" "$project_id" "$notbill"
     fi
     n=0


### PR DESCRIPTION
I got the email from toggl.com about the switch to api.track.toggl.com, so this is just replacing www.toggl.com by api.track.toggl.com in the code.

I've also added an option to specify the api token directly by command line, using `--token <api token>`, as I couldn't use username and password because I'm logging to toggl.com using my gmail account.

I've updated the help accordingly as well.